### PR TITLE
Make the plugin work with babel 7 & babel-codemod

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "babel-plugin-transform-require",
   "version": "1.0.0",
   "description": "A babel plugin to turn ES5 require call to ES6/7",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src/ --out-dir lib/",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {isVarWithRequireCalls, matchRequire, matchRequireWithProperty} from './helpers.js';
-import {types as t} from "babel-core";
 
 module.exports = function(babel) {
+  const {types: t} = babel;
   return {
     visitor: {
       VariableDeclaration: function(path) {
@@ -13,43 +13,43 @@ module.exports = function(babel) {
               dec => varToImport(dec, decalrationKind)
             )
 
-            return path.replaceWithMultiple(declarations);
+            path.replaceWithMultiple(declarations);
           }
         }
       } 
     }
   }
-}
 
-function varToImport(dec, kind) {
-  let m;
-  if ((m = matchRequire(dec))) {
-    if (m.id.type === 'ObjectPattern') {
-      return patternToNamedImport(m);
-    }
-    else if (m.id.type === 'Identifier') {
-      return t.importDeclaration([t.importDefaultSpecifier(m.id)], m.sources[0]);
-    }
-  }
-  else if ((m = matchRequireWithProperty(dec))) {
-    if (m.property.name === 'default') {
-      return t.importDeclaration([t.importDefaultSpecifier(m.id)], m.sources[0]);
-    }
-    return t.importDeclaration([t.importSpecifier(m.id, m.property)], m.sources[0])
-  }
-  else {
-    return t.variableDeclaration(kind, [dec]);
-  }
-}
-
-function patternToNamedImport({id, sources}) {
-  return t.importDeclaration(
-    id.properties.map(({key, value}) => {
-      if (key.name === 'default') {
-        return t.importDefaultSpecifier(value);
+  function varToImport(dec, kind) {
+    let m;
+    if ((m = matchRequire(dec))) {
+      if (m.id.type === 'ObjectPattern') {
+        return patternToNamedImport(m);
       }
-      return t.importSpecifier(value, key)
-    }),
-    sources[0]
-  )
-}
+      else if (m.id.type === 'Identifier') {
+        return t.importDeclaration([t.importDefaultSpecifier(m.id)], m.sources[0]);
+      }
+    }
+    else if ((m = matchRequireWithProperty(dec))) {
+      if (m.property.name === 'default') {
+        return t.importDeclaration([t.importDefaultSpecifier(m.id)], m.sources[0]);
+      }
+      return t.importDeclaration([t.importSpecifier(m.id, m.property)], m.sources[0])
+    }
+    else {
+      return t.variableDeclaration(kind, [dec]);
+    }
+  }
+
+  function patternToNamedImport({id, sources}) {
+    return t.importDeclaration(
+      id.properties.map(({key, value}) => {
+        if (key.name === 'default') {
+          return t.importDefaultSpecifier(value);
+        }
+        return t.importSpecifier(value, key)
+      }),
+      sources[0]
+    )
+  }
+};


### PR DESCRIPTION
I decided to check out this plugin after reading https://github.com/lebab/lebab/issues/138#issuecomment-376897182. I'm interested in seeing lebab made to use babel plugins and perhaps use [babel-codemod](https://github.com/square/babel-codemod) under the hood.

---

I believe the main issue was trying to call `path.replaceWithMultiple(…)` as well as returning the result of that call from the visitor function. I got this error:

```
Error: Unexpected return value from visitor method function newFn(path) {
          return fn.call(state, path, state);
        }
    at NodePath._call (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/path/context.js:71:13)
    at NodePath.call (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/path/context.js:38:17)
    at NodePath.visit (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/path/context.js:99:12)
    at TraversalContext.visitQueue (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/context.js:135:18)
    at TraversalContext.visitMultiple (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/context.js:89:17)
    at TraversalContext.visit (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/context.js:174:19)
    at Function.traverse.node (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/index.js:76:17)
    at NodePath.visit (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/path/context.js:106:18)
    at TraversalContext.visitQueue (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/context.js:135:18)
    at TraversalContext.visitSingle (/Users/donovan/src/babel-codemod/node_modules/@babel/traverse/lib/context.js:94:19)
```

Additionally, you can pull `types` from the babel object passed to your plugin rather than importing from a specific version of babel. This should make it easier to use with both babel 6 and babel 7.

Finally, the main file is compiled to `lib/index.js` so I made that the `main` entry in package.json so the package can be `require`d.